### PR TITLE
Fix serial tty handling

### DIFF
--- a/linux/golightctrl/mqtt.go
+++ b/linux/golightctrl/mqtt.go
@@ -49,7 +49,7 @@ func mqttOnConnectionHandler(mqttc *mqtt.Client) {
 		tk := mqttc.SubscribeMultiple(mqtt_topics_we_subscribed_, nil)
 		tk.Wait()
 		if tk.Error() != nil {
-			LogMQTT_.Fatalf("Error resubscribing on connect", tk.Error())
+			LogMQTT_.Fatal("Error resubscribing on connect", tk.Error())
 		}
 	}
 }

--- a/linux/golightctrl/serial_tty.go
+++ b/linux/golightctrl/serial_tty.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"syscall"
 
 	"github.com/schleibinger/sio"
@@ -49,15 +50,16 @@ func serialReader(out chan<- SerialLine, serial *sio.Port) {
 	linescanner := bufio.NewScanner(serial)
 	linescanner.Split(bufio.ScanLines)
 	for linescanner.Scan() {
-		if err := linescanner.Err(); err != nil {
-			panic(err.Error())
-		}
-		text := []byte(linescanner.Text())
+		text := linescanner.Bytes()
 		if len(text) == 0 {
 			continue
 		}
 		out <- text
 	}
+	if err := linescanner.Err(); err != nil {
+		panic(err.Error())
+	}
+	panic(fmt.Sprintf("serial device '%s' has been closed/removed", serial.LocalAddr()))
 }
 
 func OpenAndHandleSerial(filename string, serspeed uint) (chan SerialLine, chan SerialLine, error) {

--- a/linux/golightctrl/switchnames.go
+++ b/linux/golightctrl/switchnames.go
@@ -123,7 +123,7 @@ func SwitchName(name string, onoff bool) (err error) {
 		LogRF433_.Printf("Name %s does not exist in actionname_map_", name)
 		return fmt.Errorf("Name does not exist")
 	}
-	LogRF433_.Printf("SwitchName(%s,%s", name, onoff)
+	LogRF433_.Printf("SwitchName(%s,%t)", name, onoff)
 	var code []byte
 	if onoff && nm.codeon != nil {
 		code = nm.codeon


### PR DESCRIPTION
The error handling of  bufio.Scanner has been done wrongly. Now when the serial device is closed or goes away the daemon gets killed. A nicer way of handling this case would be better but at least the error is not silently ignored.

This also fixes 2 problems highlighted by go vet.
